### PR TITLE
Fix crash on smooth SV changer on duplicate points

### DIFF
--- a/Beat Program/Manage_Beatmap.cs
+++ b/Beat Program/Manage_Beatmap.cs
@@ -2698,6 +2698,7 @@ namespace Manage_Beatmap
                         else if (pointType == "0")
                         {
                             int offset = int.Parse(currentLine.Substring(0, currentLine.IndexOf(',')));
+                            greenPoints.Remove(offset);
                             greenPoints.Add(offset, i);
                             greenPointOffsets.Add(offset);
                         }


### PR DESCRIPTION
Closes #10.

The last entry of the points are added while detecting the green points in between.