### PR TITLE
Resnap objects (including 1/5, 1/7 and 1/9)

### DIFF
--- a/Beat Program/ActionableForm.cs
+++ b/Beat Program/ActionableForm.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Manage_Beatmap;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -10,6 +11,8 @@ namespace BeatmapManager
     public class ActionableForm<T>: ActionableForm where T: ActionableForm<T>
     {
         private readonly Action<T> formAction;
+        private bool willUseLoading = false;
+        private Form parent;
 
         public ActionableForm() : base()
         {
@@ -21,9 +24,28 @@ namespace BeatmapManager
             formAction = action;
         }
 
+        public virtual T UseLoading(Form parent)
+        {
+            this.parent = parent;
+            willUseLoading = true;
+            return GetThis();
+        }
+
         protected virtual void InvokeAction()
         {
+            LoadingForm loadingForm = null;
+            if (willUseLoading)
+            {
+                loadingForm = new LoadingForm();
+                loadingForm.StartPosition = FormStartPosition.CenterParent;
+                loadingForm.Show();
+                loadingForm.Top = parent.Top + ((parent.Height / 2) - (loadingForm.Height / 2));
+                loadingForm.Left = parent.Left + ((parent.Width / 2) - (loadingForm.Width / 2));
+                loadingForm.Refresh();
+            }
             formAction.Invoke(GetThis());
+            if (willUseLoading)
+                loadingForm.Close();
         }
 
         private T GetThis()

--- a/Beat Program/Extensions.cs
+++ b/Beat Program/Extensions.cs
@@ -58,9 +58,30 @@ namespace BeatmapManager
             return (int.Parse(searched) & 1) == 1;
         }
 
+        public static bool IsHitObjectNormal(this string input)
+        {
+            return (Convert.ToInt16(input.GetBetween(',', 3, 4)) & 1) == 1;
+        }
+
+        public static bool IsHitObjectSpinner(this string input)
+        {
+            return (Convert.ToInt16(input.GetBetween(',', 3, 4)) & 8) != 0;
+        }
+
+        public static bool IsHitObjectSlider(this string input)
+        {
+            return (Convert.ToInt16(input.GetBetween(',', 3, 4)) & 2) != 0;
+        }
+
         public static double GetHitObjectOffset(this string input)
         {
             string result = input.GetBetween(',', 2, 3).ReplaceDecimalSeparator();
+            return double.Parse(result);
+        }
+
+        public static double GetHitObjectSpinnerOffset(this string input)
+        {
+            string result = input.GetBetween(',', 5, 6).ReplaceDecimalSeparator();
             return double.Parse(result);
         }
 
@@ -280,7 +301,7 @@ namespace BeatmapManager
         {
             // Surely there can't be a map with -30000 ms timing point offset, right?
             double offset = -30000;
-            for (int i = input.GetTimingPointsStartIndex(); i >= 0 && !string.IsNullOrWhiteSpace(input[i]) && i < input.Length; i++)
+            for (int i = input.GetTimingPointsStartIndex(); i >= 0 && i < input.Length && !string.IsNullOrWhiteSpace(input[i]); i++)
             {
                 offset = Math.Max(offset, input[i].GetPointOffset());
             }
@@ -291,7 +312,7 @@ namespace BeatmapManager
         {
             // Surely there can't be a map with -30000 ms timing point offset, right?
             double offset = -30000;
-            for (int i = input.GetTimingPointsStartIndex(); i >= 0 && !string.IsNullOrWhiteSpace(input[i]) && i < input.Count; i++)
+            for (int i = input.GetTimingPointsStartIndex(); i >= 0 && i < input.Count && !string.IsNullOrWhiteSpace(input[i]); i++)
             {
                 offset = Math.Max(offset, input[i].GetPointOffset());
             }
@@ -301,7 +322,7 @@ namespace BeatmapManager
         public static double FindMinPointOffset(this string[] input)
         {
             double offset = double.MaxValue;
-            for (int i = input.GetTimingPointsStartIndex(); i >= 0 && !string.IsNullOrWhiteSpace(input[i]) && i < input.Length; i++)
+            for (int i = input.GetTimingPointsStartIndex(); i >= 0 && i < input.Length && !string.IsNullOrWhiteSpace(input[i]); i++)
             {
                 offset = Math.Min(offset, input[i].GetPointOffset());
             }
@@ -311,7 +332,7 @@ namespace BeatmapManager
         public static double FindMinPointOffset(this List<string> input)
         {
             double offset = double.MaxValue;
-            for (int i = input.GetTimingPointsStartIndex(); i >= 0 && !string.IsNullOrWhiteSpace(input[i]) && i < input.Count; i++)
+            for (int i = input.GetTimingPointsStartIndex(); i >= 0 && i < input.Count && !string.IsNullOrWhiteSpace(input[i]); i++)
             {
                 offset = Math.Min(offset, input[i].GetPointOffset());
             }
@@ -321,7 +342,7 @@ namespace BeatmapManager
         public static double FindMaxHitObjectOffset(this string[] input)
         {
             double offset = 0;
-            for (int i = input.GetHitObjectsStartIndex(); i >= 0 && !string.IsNullOrWhiteSpace(input[i]) && i < input.Length; i++)
+            for (int i = input.GetHitObjectsStartIndex(); i >= 0 && i < input.Length && !string.IsNullOrWhiteSpace(input[i]); i++)
             {
                 offset = Math.Max(offset, input[i].GetHitObjectOffset());
             }
@@ -331,7 +352,7 @@ namespace BeatmapManager
         public static double FindMaxHitObjectOffset(this List<string> input)
         {
             double offset = 0;
-            for (int i = input.GetHitObjectsStartIndex(); i >= 0 && !string.IsNullOrWhiteSpace(input[i]) && i < input.Count; i++)
+            for (int i = input.GetHitObjectsStartIndex(); i >= 0 && i < input.Count && !string.IsNullOrWhiteSpace(input[i]); i++)
             {
                 offset = Math.Max(offset, input[i].GetHitObjectOffset());
             }
@@ -341,7 +362,7 @@ namespace BeatmapManager
         public static double FindMinHitObjectOffset(this string[] input)
         {
             double offset = double.MaxValue;
-            for (int i = input.GetHitObjectsStartIndex(); i >= 0 && !string.IsNullOrWhiteSpace(input[i]) && i < input.Length; i++)
+            for (int i = input.GetHitObjectsStartIndex(); i >= 0 && i < input.Length && !string.IsNullOrWhiteSpace(input[i]); i++)
             {
                 offset = Math.Min(offset, input[i].GetHitObjectOffset());
             }
@@ -351,7 +372,7 @@ namespace BeatmapManager
         public static double FindMinHitObjectOffset(this List<string> input)
         {
             double offset = double.MaxValue;
-            for (int i = input.GetHitObjectsStartIndex(); i >= 0 && !string.IsNullOrWhiteSpace(input[i]) && i < input.Count; i++)
+            for (int i = input.GetHitObjectsStartIndex(); i >= 0 && i < input.Count && !string.IsNullOrWhiteSpace(input[i]); i++)
             {
                 offset = Math.Min(offset, input[i].GetHitObjectOffset());
             }

--- a/Beat Program/Extensions.cs
+++ b/Beat Program/Extensions.cs
@@ -32,6 +32,29 @@ namespace BeatmapManager
             return int.Parse(new string(input.Where(char.IsDigit).ToArray()));
         }
 
+        public static decimal RoundIfTooClose(this decimal input)
+        {
+            string inputString = input.ToString();
+            int precisionIndex = inputString.IndexOf(Program.GetDecimalSeparator());
+            if (precisionIndex == -1 || precisionIndex == inputString.Length - 1)
+                return input;
+
+            string floatingPointValue = inputString.Substring(precisionIndex + 1);
+            if (floatingPointValue.Length > 11 && floatingPointValue.Substring(0, 11).IsAllEqualTo('9'))
+                return Math.Round(input);
+            else
+                return input;
+        }
+
+        public static bool IsAllEqualTo(this string input, char searched)
+        {
+            for (int i = 0; i < input.Length; i++)
+                if (input[i] != searched)
+                    return false;
+
+            return true;
+        }
+
         public static double GetPointOffset(this string input)
         {
             int index = input.IndexOf(',');

--- a/Beat Program/LoadingForm.Designer.cs
+++ b/Beat Program/LoadingForm.Designer.cs
@@ -1,0 +1,66 @@
+﻿namespace Manage_Beatmap
+{
+    partial class LoadingForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.label1 = new System.Windows.Forms.Label();
+            this.SuspendLayout();
+            // 
+            // label1
+            // 
+            this.label1.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.label1.AutoSize = true;
+            this.label1.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.label1.Location = new System.Drawing.Point(50, 29);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(54, 13);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "Loading...";
+            // 
+            // LoadingForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.ClientSize = new System.Drawing.Size(154, 71);
+            this.ControlBox = false;
+            this.Controls.Add(this.label1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
+            this.Name = "LoadingForm";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Info";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label label1;
+    }
+}

--- a/Beat Program/LoadingForm.cs
+++ b/Beat Program/LoadingForm.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows.Forms;
+
+namespace Manage_Beatmap
+{
+    public partial class LoadingForm : Form
+    {
+        public LoadingForm()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Beat Program/LoadingForm.resx
+++ b/Beat Program/LoadingForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Beat Program/MainForm.cs
+++ b/Beat Program/MainForm.cs
@@ -12,6 +12,7 @@ using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Diagnostics;
+using Manage_Beatmap;
 
 namespace BeatmapManager
 {
@@ -49,6 +50,13 @@ namespace BeatmapManager
                 cp.ExStyle |= 0x02000000;  // Turn on WS_EX_COMPOSITED
                 return cp;
             }
+        }
+
+        private enum BeatmapMultiResult
+        {
+            SINGLE,
+            MULTI,
+            CANCEL
         }
 
         public MainForm()
@@ -336,6 +344,7 @@ namespace BeatmapManager
             activeComboBoxItems.Add(language.LanguageContent[Language.positionNotesButton]);
             // activeComboBoxItems[5] = language.LanguageContent[Language.newTimingButton];
             activeComboBoxItems.Add(language.LanguageContent[Language.changeBPMofSelectedPointButton]);
+            activeComboBoxItems.Add("Resnap objects (1/5, 1/7, 1/9 included)");
             // activeComboBoxItems[7] = language.LanguageContent[Language.changeOffsetsOfSelectedPointsButton];
             activeComboBoxItems.Add(language.LanguageContent[Language.addInheritedPointsToChangeSVsmoothlyButton]);
             activeComboBoxItems.Add(language.LanguageContent[Language.equalizeSVforAllTimingPointsButton]);
@@ -2525,6 +2534,37 @@ namespace BeatmapManager
             formHandlerPanel.SetForm(form);
         }
 
+        private void ResnapObjects()
+        {
+            ResnapObjectsForm resnapObjectsForm = new ResnapObjectsForm(form =>
+            {
+                ResnapObjectsForm.Members members = form.Values;
+                if (members.IsAllTaikoDiffs)
+                {
+                    BeatmapMultiResult result = ManageBackupMultiDiffs();
+                    if (result == BeatmapMultiResult.CANCEL)
+                        return;
+                    else if (result == BeatmapMultiResult.SINGLE)
+                        ResnapObjects(members, path, true);
+                    else
+                    {
+                        // Can be multiple diffs only.
+                        List<FileInfo> taikoDiffs = GetTaikoDiffs();
+                        for (int i = 0; i < taikoDiffs.Count; i++)
+                        {
+                            ResnapObjects(members, taikoDiffs[i].FullName, i == taikoDiffs.Count - 1);
+                        }
+                    }
+                }
+            });
+            formHandlerPanel.SetForm(resnapObjectsForm);
+        }
+
+        private void ResnapObjects(ResnapObjectsForm.Members members, string path, bool lastDiff)
+        {
+            throw new NotImplementedException();
+        }
+
         private void SmoothSvChanger()
         {
             SV_Changer svChanger = new SV_Changer(form =>
@@ -3055,35 +3095,62 @@ namespace BeatmapManager
             return previousIndex;
         }
 
+        private List<FileInfo> GetTaikoDiffs()
+        {
+            if (string.IsNullOrEmpty(path))
+                return new List<FileInfo>();
+
+            DirectoryInfo folder = Directory.GetParent(path);
+            List<FileInfo> taikoDiffs = folder.GetFiles().Where(info => File.ReadAllLines(info.FullName).IsTaikoDifficulty()).ToList();
+            return taikoDiffs;
+        }
+
+        private BeatmapMultiResult ManageBackupMultiDiffs()
+        {
+            DirectoryInfo folder = Directory.GetParent(path);
+            List<FileInfo> taikoDiffs = GetTaikoDiffs();
+            if (taikoDiffs.Count > 1)
+            {
+                DialogResult result = ShowMode.QuestionWithYesNoCancel("The beatmapset contains multiple taiko diffs and backups inside Manage Beatmap tool cannot be created.\n\nDo you want to save the backups to the Desktop?");
+                if (result == DialogResult.Cancel)
+                    return BeatmapMultiResult.CANCEL;
+                else if (result == DialogResult.Yes)
+                {
+                    // Save the current diffs to desktop here.
+                    string desktopPath = Environment.GetFolderPath(Environment.SpecialFolder.Desktop) + "\\" + folder.Name;
+
+                    // Check if the directory can be created.
+                    if (Directory.CreateDirectory(desktopPath).Exists)
+                    {
+                        foreach (FileInfo diff in taikoDiffs)
+                        {
+                            File.Copy(diff.FullName, desktopPath + "\\" + diff.Name);
+                        }
+                    }
+                }
+                return BeatmapMultiResult.MULTI;
+            }
+            else
+                return BeatmapMultiResult.SINGLE;
+        }
+
         private void SVequalizer()
         {
             formHandlerPanel.SetForm(new SV_Equalizer(equalizerForm =>
             {
                 if (equalizerForm.ApplyToAllTaikoDiffs)
                 {
-                    DirectoryInfo folder = Directory.GetParent(path);
-                    List<FileInfo> taikoDiffs = folder.GetFiles().Where(info => File.ReadAllLines(info.FullName).IsTaikoDifficulty()).ToList();
-                    if (taikoDiffs.Count > 1)
+                    BeatmapMultiResult result = ManageBackupMultiDiffs();
+                    if (result == BeatmapMultiResult.SINGLE)
                     {
-                        DialogResult result = ShowMode.QuestionWithYesNoCancel("The beatmapset contains multiple taiko diffs and backups inside Manage Beatmap tool cannot be created.\n\nDo you want to save the backups to the Desktop?");
-                        if (result == DialogResult.Cancel)
-                            return;
-                        else if (result == DialogResult.Yes)
-                        {
-                            // Save the current diffs to desktop here.
-                            string desktopPath = Environment.GetFolderPath(Environment.SpecialFolder.Desktop) + "\\" + folder.Name;
-
-                            // Check if the directory can be created.
-                            if (Directory.CreateDirectory(desktopPath).Exists)
-                            {
-                                foreach (FileInfo diff in taikoDiffs)
-                                {
-                                    File.Copy(diff.FullName, desktopPath + "\\" + diff.Name);
-                                }
-                            }
-                        }
-
+                        // Add a backup and equalize SV.
+                        AddBackup();
+                        EqualizeSvInDiff(equalizerForm, path, true);
+                    }
+                    else if (result == BeatmapMultiResult.MULTI)
+                    {
                         // If we reach here, it means the SVs should be equalized.
+                        List<FileInfo> taikoDiffs = GetTaikoDiffs();
                         int count = taikoDiffs.Count;
                         int changedFileCount = 0;
                         for (int i = 0; i < count; i++)
@@ -3098,12 +3165,6 @@ namespace BeatmapManager
                             else
                                 changedFileCount++;
                         }
-                    }
-                    else
-                    {
-                        // Add a backup and equalize SV.
-                        AddBackup();
-                        EqualizeSvInDiff(equalizerForm, path, true);
                     }
                 }
                 else
@@ -3416,21 +3477,24 @@ namespace BeatmapManager
                     ChangeOffset();
                     break;*/
                 case 4:
-                    SmoothSvChanger();
+                    ResnapObjects();
                     break;
                 case 5:
-                    SVequalizer();
+                    SmoothSvChanger();
                     break;
                 case 6:
-                    SVchanger();
+                    SVequalizer();
                     break;
                 case 7:
-                    SVstepbystep();
+                    SVchanger();
                     break;
                 case 8:
-                    VolumeChanger();
+                    SVstepbystep();
                     break;
                 case 9:
+                    VolumeChanger();
+                    break;
+                case 10:
                     VolumeStepByStep();
                     break;
                 /*case 14:
@@ -3445,7 +3509,7 @@ namespace BeatmapManager
                 case 17:
                     DeleteUnneccessaryInheritedPoints();
                     break;*/
-                case 10:
+                case 11:
                     MetadataManager();
                     break;
                 default:

--- a/Beat Program/Manage Beatmap.csproj
+++ b/Beat Program/Manage Beatmap.csproj
@@ -115,6 +115,12 @@
     </Compile>
     <Compile Include="Language.cs" />
     <Compile Include="Extensions.cs" />
+    <Compile Include="LoadingForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="LoadingForm.Designer.cs">
+      <DependentUpon>LoadingForm.cs</DependentUpon>
+    </Compile>
     <Compile Include="MainForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -173,6 +179,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Hitsounds.resx">
       <DependentUpon>Hitsounds.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="LoadingForm.resx">
+      <DependentUpon>LoadingForm.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="MainForm.resx">
       <DependentUpon>MainForm.cs</DependentUpon>

--- a/Beat Program/Manage Beatmap.csproj
+++ b/Beat Program/Manage Beatmap.csproj
@@ -142,6 +142,12 @@
     </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ResnapObjectsForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="ResnapObjectsForm.Designer.cs">
+      <DependentUpon>ResnapObjectsForm.cs</DependentUpon>
+    </Compile>
     <Compile Include="SV_Changer.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -190,6 +196,9 @@
       <DependentUpon>Resources.resx</DependentUpon>
       <DesignTime>True</DesignTime>
     </Compile>
+    <EmbeddedResource Include="ResnapObjectsForm.resx">
+      <DependentUpon>ResnapObjectsForm.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="SV_Changer.resx">
       <DependentUpon>SV_Changer.cs</DependentUpon>
     </EmbeddedResource>

--- a/Beat Program/ResnapObjectsForm.Designer.cs
+++ b/Beat Program/ResnapObjectsForm.Designer.cs
@@ -1,0 +1,202 @@
+﻿
+namespace Manage_Beatmap
+{
+    partial class ResnapObjectsForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.wholeMapCheckBox = new System.Windows.Forms.CheckBox();
+            this.allTaikoDiffsCheckBox = new System.Windows.Forms.CheckBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.startOffsetTextBox = new System.Windows.Forms.TextBox();
+            this.endOffsetTextBox = new System.Windows.Forms.TextBox();
+            this.label2 = new System.Windows.Forms.Label();
+            this.applyButton = new System.Windows.Forms.Button();
+            this.snapGreenLinesCheckBox = new System.Windows.Forms.CheckBox();
+            this.snapBookmarksCheckBox = new System.Windows.Forms.CheckBox();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.SuspendLayout();
+            // 
+            // wholeMapCheckBox
+            // 
+            this.wholeMapCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Top;
+            this.wholeMapCheckBox.AutoSize = true;
+            this.wholeMapCheckBox.Checked = true;
+            this.wholeMapCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.wholeMapCheckBox.Location = new System.Drawing.Point(93, 82);
+            this.wholeMapCheckBox.Margin = new System.Windows.Forms.Padding(5);
+            this.wholeMapCheckBox.Name = "wholeMapCheckBox";
+            this.wholeMapCheckBox.Size = new System.Drawing.Size(183, 24);
+            this.wholeMapCheckBox.TabIndex = 0;
+            this.wholeMapCheckBox.Text = "Apply to whole map";
+            this.toolTip1.SetToolTip(this.wholeMapCheckBox, "Allows you to resnap everything based\r\non the settings to the whole map.\r\n\r\nIf yo" +
+        "u want to resnap only a section,\r\nuncheck this and enter start and end\r\noffsets." +
+        "");
+            this.wholeMapCheckBox.UseVisualStyleBackColor = true;
+            this.wholeMapCheckBox.CheckedChanged += new System.EventHandler(this.wholeMapCheckBox_CheckedChanged);
+            // 
+            // allTaikoDiffsCheckBox
+            // 
+            this.allTaikoDiffsCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Top;
+            this.allTaikoDiffsCheckBox.AutoSize = true;
+            this.allTaikoDiffsCheckBox.Location = new System.Drawing.Point(61, 116);
+            this.allTaikoDiffsCheckBox.Margin = new System.Windows.Forms.Padding(5);
+            this.allTaikoDiffsCheckBox.Name = "allTaikoDiffsCheckBox";
+            this.allTaikoDiffsCheckBox.Size = new System.Drawing.Size(247, 24);
+            this.allTaikoDiffsCheckBox.TabIndex = 1;
+            this.allTaikoDiffsCheckBox.Text = "Apply to all taiko difficulties";
+            this.toolTip1.SetToolTip(this.allTaikoDiffsCheckBox, "Applies the selected functions to all\r\ntaiko difficulties. Other mode diffs\r\nare " +
+        "untouched.");
+            this.allTaikoDiffsCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(13, 163);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(106, 20);
+            this.label1.TabIndex = 2;
+            this.label1.Text = "Start offset:";
+            // 
+            // startOffsetTextBox
+            // 
+            this.startOffsetTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.startOffsetTextBox.Enabled = false;
+            this.startOffsetTextBox.Location = new System.Drawing.Point(125, 160);
+            this.startOffsetTextBox.Name = "startOffsetTextBox";
+            this.startOffsetTextBox.Size = new System.Drawing.Size(231, 26);
+            this.startOffsetTextBox.TabIndex = 3;
+            this.toolTip1.SetToolTip(this.startOffsetTextBox, "The start offset to begin resnapping from.");
+            // 
+            // endOffsetTextBox
+            // 
+            this.endOffsetTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.endOffsetTextBox.Enabled = false;
+            this.endOffsetTextBox.Location = new System.Drawing.Point(125, 192);
+            this.endOffsetTextBox.Name = "endOffsetTextBox";
+            this.endOffsetTextBox.Size = new System.Drawing.Size(231, 26);
+            this.endOffsetTextBox.TabIndex = 5;
+            this.toolTip1.SetToolTip(this.endOffsetTextBox, "The end offset to end resnappings.");
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(13, 195);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(98, 20);
+            this.label2.TabIndex = 4;
+            this.label2.Text = "End offset:";
+            // 
+            // applyButton
+            // 
+            this.applyButton.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.applyButton.BackColor = System.Drawing.SystemColors.ControlLightLight;
+            this.applyButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.applyButton.ImeMode = System.Windows.Forms.ImeMode.NoControl;
+            this.applyButton.Location = new System.Drawing.Point(12, 234);
+            this.applyButton.Name = "applyButton";
+            this.applyButton.Size = new System.Drawing.Size(344, 35);
+            this.applyButton.TabIndex = 9;
+            this.applyButton.Text = "Apply";
+            this.toolTip1.SetToolTip(this.applyButton, "plz support me on patreon");
+            this.applyButton.UseVisualStyleBackColor = false;
+            this.applyButton.Click += new System.EventHandler(this.applyButton_Click);
+            // 
+            // snapGreenLinesCheckBox
+            // 
+            this.snapGreenLinesCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Top;
+            this.snapGreenLinesCheckBox.AutoSize = true;
+            this.snapGreenLinesCheckBox.Checked = true;
+            this.snapGreenLinesCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.snapGreenLinesCheckBox.Location = new System.Drawing.Point(41, 14);
+            this.snapGreenLinesCheckBox.Margin = new System.Windows.Forms.Padding(5);
+            this.snapGreenLinesCheckBox.Name = "snapGreenLinesCheckBox";
+            this.snapGreenLinesCheckBox.Size = new System.Drawing.Size(287, 24);
+            this.snapGreenLinesCheckBox.TabIndex = 10;
+            this.snapGreenLinesCheckBox.Text = "Snap green lines if behind notes";
+            this.toolTip1.SetToolTip(this.snapGreenLinesCheckBox, "Snaps the green lines with -1ms offset\r\nif the result causes the green lines\r\nto " +
+        "be after the notes by a 10ms margin.\r\n\r\nEnabling this will not move green lines\r" +
+        "\nthat change kiai state.");
+            this.snapGreenLinesCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // snapBookmarksCheckBox
+            // 
+            this.snapBookmarksCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Top;
+            this.snapBookmarksCheckBox.AutoSize = true;
+            this.snapBookmarksCheckBox.Location = new System.Drawing.Point(103, 48);
+            this.snapBookmarksCheckBox.Margin = new System.Windows.Forms.Padding(5);
+            this.snapBookmarksCheckBox.Name = "snapBookmarksCheckBox";
+            this.snapBookmarksCheckBox.Size = new System.Drawing.Size(162, 24);
+            this.snapBookmarksCheckBox.TabIndex = 11;
+            this.snapBookmarksCheckBox.Text = "Snap bookmarks";
+            this.toolTip1.SetToolTip(this.snapBookmarksCheckBox, "Snaps the bookmarks to closest snap if enabled.");
+            this.snapBookmarksCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // ResnapObjectsForm
+            // 
+            this.AcceptButton = this.applyButton;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 20F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.BackColor = System.Drawing.SystemColors.ActiveCaption;
+            this.ClientSize = new System.Drawing.Size(368, 287);
+            this.Controls.Add(this.snapBookmarksCheckBox);
+            this.Controls.Add(this.snapGreenLinesCheckBox);
+            this.Controls.Add(this.applyButton);
+            this.Controls.Add(this.endOffsetTextBox);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.startOffsetTextBox);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.allTaikoDiffsCheckBox);
+            this.Controls.Add(this.wholeMapCheckBox);
+            this.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(162)));
+            this.Margin = new System.Windows.Forms.Padding(5);
+            this.Name = "ResnapObjectsForm";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "ResnapObjectsForm";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.CheckBox wholeMapCheckBox;
+        private System.Windows.Forms.CheckBox allTaikoDiffsCheckBox;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.TextBox startOffsetTextBox;
+        private System.Windows.Forms.TextBox endOffsetTextBox;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Button applyButton;
+        private System.Windows.Forms.ToolTip toolTip1;
+        private System.Windows.Forms.CheckBox snapGreenLinesCheckBox;
+        private System.Windows.Forms.CheckBox snapBookmarksCheckBox;
+    }
+}

--- a/Beat Program/ResnapObjectsForm.Designer.cs
+++ b/Beat Program/ResnapObjectsForm.Designer.cs
@@ -38,7 +38,6 @@ namespace Manage_Beatmap
             this.label2 = new System.Windows.Forms.Label();
             this.applyButton = new System.Windows.Forms.Button();
             this.snapGreenLinesCheckBox = new System.Windows.Forms.CheckBox();
-            this.snapBookmarksCheckBox = new System.Windows.Forms.CheckBox();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.SuspendLayout();
             // 
@@ -48,7 +47,7 @@ namespace Manage_Beatmap
             this.wholeMapCheckBox.AutoSize = true;
             this.wholeMapCheckBox.Checked = true;
             this.wholeMapCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.wholeMapCheckBox.Location = new System.Drawing.Point(93, 82);
+            this.wholeMapCheckBox.Location = new System.Drawing.Point(93, 43);
             this.wholeMapCheckBox.Margin = new System.Windows.Forms.Padding(5);
             this.wholeMapCheckBox.Name = "wholeMapCheckBox";
             this.wholeMapCheckBox.Size = new System.Drawing.Size(183, 24);
@@ -64,7 +63,7 @@ namespace Manage_Beatmap
             // 
             this.allTaikoDiffsCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Top;
             this.allTaikoDiffsCheckBox.AutoSize = true;
-            this.allTaikoDiffsCheckBox.Location = new System.Drawing.Point(61, 116);
+            this.allTaikoDiffsCheckBox.Location = new System.Drawing.Point(61, 77);
             this.allTaikoDiffsCheckBox.Margin = new System.Windows.Forms.Padding(5);
             this.allTaikoDiffsCheckBox.Name = "allTaikoDiffsCheckBox";
             this.allTaikoDiffsCheckBox.Size = new System.Drawing.Size(247, 24);
@@ -77,7 +76,7 @@ namespace Manage_Beatmap
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(13, 163);
+            this.label1.Location = new System.Drawing.Point(11, 124);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(106, 20);
             this.label1.TabIndex = 2;
@@ -88,7 +87,7 @@ namespace Manage_Beatmap
             this.startOffsetTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.startOffsetTextBox.Enabled = false;
-            this.startOffsetTextBox.Location = new System.Drawing.Point(125, 160);
+            this.startOffsetTextBox.Location = new System.Drawing.Point(123, 121);
             this.startOffsetTextBox.Name = "startOffsetTextBox";
             this.startOffsetTextBox.Size = new System.Drawing.Size(231, 26);
             this.startOffsetTextBox.TabIndex = 3;
@@ -99,7 +98,7 @@ namespace Manage_Beatmap
             this.endOffsetTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.endOffsetTextBox.Enabled = false;
-            this.endOffsetTextBox.Location = new System.Drawing.Point(125, 192);
+            this.endOffsetTextBox.Location = new System.Drawing.Point(123, 153);
             this.endOffsetTextBox.Name = "endOffsetTextBox";
             this.endOffsetTextBox.Size = new System.Drawing.Size(231, 26);
             this.endOffsetTextBox.TabIndex = 5;
@@ -108,7 +107,7 @@ namespace Manage_Beatmap
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(13, 195);
+            this.label2.Location = new System.Drawing.Point(11, 156);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(98, 20);
             this.label2.TabIndex = 4;
@@ -121,7 +120,7 @@ namespace Manage_Beatmap
             this.applyButton.BackColor = System.Drawing.SystemColors.ControlLightLight;
             this.applyButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.applyButton.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.applyButton.Location = new System.Drawing.Point(12, 234);
+            this.applyButton.Location = new System.Drawing.Point(12, 195);
             this.applyButton.Name = "applyButton";
             this.applyButton.Size = new System.Drawing.Size(344, 35);
             this.applyButton.TabIndex = 9;
@@ -136,7 +135,7 @@ namespace Manage_Beatmap
             this.snapGreenLinesCheckBox.AutoSize = true;
             this.snapGreenLinesCheckBox.Checked = true;
             this.snapGreenLinesCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.snapGreenLinesCheckBox.Location = new System.Drawing.Point(41, 14);
+            this.snapGreenLinesCheckBox.Location = new System.Drawing.Point(41, 9);
             this.snapGreenLinesCheckBox.Margin = new System.Windows.Forms.Padding(5);
             this.snapGreenLinesCheckBox.Name = "snapGreenLinesCheckBox";
             this.snapGreenLinesCheckBox.Size = new System.Drawing.Size(287, 24);
@@ -147,27 +146,13 @@ namespace Manage_Beatmap
         "\nthat change kiai state.");
             this.snapGreenLinesCheckBox.UseVisualStyleBackColor = true;
             // 
-            // snapBookmarksCheckBox
-            // 
-            this.snapBookmarksCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Top;
-            this.snapBookmarksCheckBox.AutoSize = true;
-            this.snapBookmarksCheckBox.Location = new System.Drawing.Point(103, 48);
-            this.snapBookmarksCheckBox.Margin = new System.Windows.Forms.Padding(5);
-            this.snapBookmarksCheckBox.Name = "snapBookmarksCheckBox";
-            this.snapBookmarksCheckBox.Size = new System.Drawing.Size(162, 24);
-            this.snapBookmarksCheckBox.TabIndex = 11;
-            this.snapBookmarksCheckBox.Text = "Snap bookmarks";
-            this.toolTip1.SetToolTip(this.snapBookmarksCheckBox, "Snaps the bookmarks to closest snap if enabled.");
-            this.snapBookmarksCheckBox.UseVisualStyleBackColor = true;
-            // 
             // ResnapObjectsForm
             // 
             this.AcceptButton = this.applyButton;
             this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.SystemColors.ActiveCaption;
-            this.ClientSize = new System.Drawing.Size(368, 287);
-            this.Controls.Add(this.snapBookmarksCheckBox);
+            this.ClientSize = new System.Drawing.Size(368, 239);
             this.Controls.Add(this.snapGreenLinesCheckBox);
             this.Controls.Add(this.applyButton);
             this.Controls.Add(this.endOffsetTextBox);
@@ -197,6 +182,5 @@ namespace Manage_Beatmap
         private System.Windows.Forms.Button applyButton;
         private System.Windows.Forms.ToolTip toolTip1;
         private System.Windows.Forms.CheckBox snapGreenLinesCheckBox;
-        private System.Windows.Forms.CheckBox snapBookmarksCheckBox;
     }
 }

--- a/Beat Program/ResnapObjectsForm.cs
+++ b/Beat Program/ResnapObjectsForm.cs
@@ -1,0 +1,122 @@
+﻿using BeatmapManager;
+using MessageBoxMode;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace Manage_Beatmap
+{
+    public partial class ResnapObjectsForm
+        #if DEBUG
+            : ActionableForm<ResnapObjectsForm>
+        #else
+            : ActionableForm  
+        #endif
+    {
+        public class Members
+        {
+            public double StartOffset { get; internal set; } = 0;
+            public double EndOffset { get; internal set; } = 0;
+
+            public bool IsSnapGreenLines { get; internal set; } = true;
+            public bool IsSnapBookmarks { get; internal set; } = false;
+            public bool IsWholeMap { get; internal set; } = true;
+            public bool IsAllTaikoDiffs { get; internal set; } = false;
+
+            internal void Reset()
+            {
+                StartOffset = 0;
+                EndOffset = 0;
+                IsSnapGreenLines = true;
+                IsSnapBookmarks = false;
+                IsWholeMap = true;
+                IsAllTaikoDiffs = false;
+            }
+        }
+
+        // cannot believe I had to rename the class
+        // because the variable could not have the same name
+        // holy shit c# you prove yourself to be worse than java
+        // day by day
+        public Members Values { get; } = new Members();
+
+        public ResnapObjectsForm(Action<ResnapObjectsForm> action) : base(action)
+        {
+            InitializeComponent();
+            startOffsetTextBox.Focus();
+        }
+
+        public ResnapObjectsForm() : base()
+        {
+            InitializeComponent();
+            startOffsetTextBox.Focus();
+        }
+
+        private void wholeMapCheckBox_CheckedChanged(object sender, EventArgs e)
+        {
+            if (wholeMapCheckBox.Checked)
+            {
+                startOffsetTextBox.Clear();
+                startOffsetTextBox.Enabled = false;
+                endOffsetTextBox.Clear();
+                endOffsetTextBox.Enabled = false;
+            }
+            else
+            {
+                startOffsetTextBox.Enabled = true;
+                endOffsetTextBox.Enabled = true;
+                startOffsetTextBox.Focus();
+            }
+        }
+
+        private void applyButton_Click(object sender, EventArgs e)
+        {
+            if (validate())
+                InvokeAction();
+        }
+
+        private bool validate()
+        {
+            double startOffset, endOffset;
+            if (!wholeMapCheckBox.Checked)
+            {
+                if (!startOffsetTextBox.IsValidOffsetInput())
+                {
+                    ShowMode.Error("Start offset: " + MainForm.language.LanguageContent[Language.timeExpressionDoesNotMatch]);
+                    Values.Reset();
+                    return false;
+                }
+                else if (!endOffsetTextBox.IsValidOffsetInput())
+                {
+                    ShowMode.Error("End offset: " + MainForm.language.LanguageContent[Language.timeExpressionDoesNotMatch]);
+                    Values.Reset();
+                    return false;
+                }
+                else
+                {
+                    startOffset = startOffsetTextBox.GetOffsetMillis();
+                    endOffset = endOffsetTextBox.GetOffsetMillis();
+                }
+            }
+            else
+            {
+                startOffset = 0;
+                endOffset = 0;
+            }
+
+            Values.StartOffset = startOffset;
+            Values.EndOffset = endOffset;
+            Values.IsAllTaikoDiffs = allTaikoDiffsCheckBox.Checked;
+            Values.IsWholeMap = wholeMapCheckBox.Checked;
+            Values.IsSnapGreenLines = snapGreenLinesCheckBox.Checked;
+            Values.IsSnapBookmarks = snapBookmarksCheckBox.Checked;
+            return true;
+        }
+    }
+}

--- a/Beat Program/ResnapObjectsForm.cs
+++ b/Beat Program/ResnapObjectsForm.cs
@@ -12,12 +12,7 @@ using System.Windows.Forms;
 
 namespace Manage_Beatmap
 {
-    public partial class ResnapObjectsForm
-        #if DEBUG
-            : ActionableForm<ResnapObjectsForm>
-        #else
-            : ActionableForm  
-        #endif
+    public partial class ResnapObjectsForm: ActionableForm<ResnapObjectsForm>
     {
         public class Members
         {
@@ -25,7 +20,6 @@ namespace Manage_Beatmap
             public double EndOffset { get; internal set; } = 0;
 
             public bool IsSnapGreenLines { get; internal set; } = true;
-            public bool IsSnapBookmarks { get; internal set; } = false;
             public bool IsWholeMap { get; internal set; } = true;
             public bool IsAllTaikoDiffs { get; internal set; } = false;
 
@@ -34,7 +28,6 @@ namespace Manage_Beatmap
                 StartOffset = 0;
                 EndOffset = 0;
                 IsSnapGreenLines = true;
-                IsSnapBookmarks = false;
                 IsWholeMap = true;
                 IsAllTaikoDiffs = false;
             }
@@ -115,7 +108,6 @@ namespace Manage_Beatmap
             Values.IsAllTaikoDiffs = allTaikoDiffsCheckBox.Checked;
             Values.IsWholeMap = wholeMapCheckBox.Checked;
             Values.IsSnapGreenLines = snapGreenLinesCheckBox.Checked;
-            Values.IsSnapBookmarks = snapBookmarksCheckBox.Checked;
             return true;
         }
     }

--- a/Beat Program/ResnapObjectsForm.resx
+++ b/Beat Program/ResnapObjectsForm.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>


### PR DESCRIPTION
At the end of this PR, the tool should have a stable resnap mechanism to various objects (hitobjects for sure, and green lines and bookmarks if desired) with the ability to resnap within a selected region or to the whole map, and will do it simultaneously on all taiko diffs if desired.